### PR TITLE
data_email.py: "SyntaxError: '(' was never closed"

### DIFF
--- a/data_email.py
+++ b/data_email.py
@@ -9,4 +9,4 @@ try:
         time.sleep(1)
         os.system("python src/data_email.cpython-310.opt-2.pyc")
 except KeyboardInterrupt:
-        sys.exit(
+        sys.exit()


### PR DESCRIPTION
In data_email.py there is an error "SyntaxError: '(' was never closed"
I fixed this just by adding ")" in the end!